### PR TITLE
Add wrapper for connection handler. Codec refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,96 @@
+### Scala template
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+### SBT template
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+target/
+lib_managed/
+src_managed/
+project/boot/
+.history
+.cache
+### PlayFramework template
+# Ignore Play! working directory #
+bin/
+/db
+.eclipse
+/lib/
+/logs/
+/modules
+/project/project
+/project/target
+/target
+tmp/
+test-result
+server.pid
+*.iml
+*.eml
+/dist/
+.cache
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
 project/target/
 target/

--- a/src/main/scala/com/lenar/ApplicationMain.scala
+++ b/src/main/scala/com/lenar/ApplicationMain.scala
@@ -1,13 +1,29 @@
 package com.lenar
 
-import akka.actor.ActorSystem
+import akka.actor._
+import com.lenar.codecs.Codecs.FrameCodec
+import com.lenar.codecs._
 
 object ApplicationMain extends App {
   val host = "localhost"
   val port = 8089
 
   val system = ActorSystem("MyActorSystem")
-  val frontend = system.actorOf(TcpFrontend.props(host, port), "FrontendActor")
+  //val codec: FrameCodec = (PrefixLengthFrameCodec.read, PrefixLengthFrameCodec.write)
+  val codec: FrameCodec = (IdentityCodec.read, IdentityCodec.write)
+  val frontend = system.actorOf(TcpFrontend.props(host, port, out => (Props(classOf[ConnectionActor], out), codec)), "FrontendActor")
 
   system.awaitTermination()
 }
+
+class ConnectionActor(out: ActorRef) extends Actor with ActorLogging {
+
+  override def receive: Actor.Receive = {
+
+    case msg: String =>
+      log.info(s"I received $msg. Sending reply...")
+      out ! s"Received $msg"
+  }
+
+}
+

--- a/src/main/scala/com/lenar/codecs/Codecs.scala
+++ b/src/main/scala/com/lenar/codecs/Codecs.scala
@@ -1,0 +1,9 @@
+package com.lenar.codecs
+
+import akka.util.ByteString
+
+object Codecs {
+  type FrameReader = ByteString => (ByteString, Seq[String])
+  type FrameWriter = String => ByteString
+  type FrameCodec = (FrameReader, FrameWriter)
+}

--- a/src/main/scala/com/lenar/codecs/IdentityCodec.scala
+++ b/src/main/scala/com/lenar/codecs/IdentityCodec.scala
@@ -1,0 +1,8 @@
+package com.lenar.codecs
+
+import akka.util.ByteString
+
+object IdentityCodec {
+  def read(buffer: ByteString): (ByteString, Seq[String]) = (ByteString.empty, Seq(buffer.utf8String))
+  def write(data: String): ByteString = ByteString(data)
+}

--- a/src/main/scala/com/lenar/codecs/PrefixLengthFrameCodec.scala
+++ b/src/main/scala/com/lenar/codecs/PrefixLengthFrameCodec.scala
@@ -1,0 +1,37 @@
+package com.lenar.codecs
+
+import java.nio.{ByteBuffer, ByteOrder}
+import akka.util.ByteString
+
+import scala.collection.immutable.Queue
+
+object PrefixLengthFrameCodec {
+  val frameHeaderSize = 4
+
+  def read(buffer: ByteString): (ByteString, Seq[String]) =
+    read(buffer, Queue.empty)
+
+  def read(buffer: ByteString, frames: Queue[String]): (ByteString, Queue[String]) =
+    if (buffer.size < frameHeaderSize) {
+      (buffer, frames)
+    }
+    else {
+      val (lengthBytes, restBuffer) = buffer.splitAt(frameHeaderSize)
+      val frameLength: Int = lengthBytes.toByteBuffer.order(ByteOrder.LITTLE_ENDIAN).getInt
+
+      if (restBuffer.size < frameLength)
+        (buffer, frames)
+      else {
+        val (frame, nextBuffer) = restBuffer.splitAt(frameLength)
+        read(nextBuffer, frames.enqueue(frame.utf8String))
+      }
+    }
+
+  def write(data: String): ByteString = {
+    val header = ByteBuffer.allocate(frameHeaderSize)
+    header.putInt(data.length)
+    ByteString(header) ++ ByteString(data)
+  }
+}
+
+


### PR DESCRIPTION
New workflow example in ApplicationMain.
- Fix decoding bug when the client sends messages split between frames
- Add ability to send messages back to the connected clients
- Allows injecting frame codecs

Test with
A) run unchanged

```
$ nc localhost 8089
Hello, world
Received Hello, world
```

B) uncomment PrefixLengthFrameCodec in ApplicationMain, run

```
$ echo "\x05\x00\x00\x00Hello" | nc localhost 8089
```
